### PR TITLE
Child command calls

### DIFF
--- a/CliTemplate/CommandFailureException.cs
+++ b/CliTemplate/CommandFailureException.cs
@@ -1,0 +1,21 @@
+﻿namespace CliTemplate;
+
+public class CommandFailureException : Exception
+{
+    public int ExitCode { get; }
+
+    public CommandFailureException(int exitCode)
+    {
+        ExitCode = exitCode;
+    }
+
+    public CommandFailureException(int exitCode, string message) : base(message)
+    {
+        ExitCode = exitCode;
+    }
+
+    public CommandFailureException(int exitCode, string message, Exception inner) : base(message, inner)
+    {
+        ExitCode = exitCode;
+    }
+}

--- a/CliTemplate/GitInfo/GitInfoCommand.cs
+++ b/CliTemplate/GitInfo/GitInfoCommand.cs
@@ -16,7 +16,7 @@ public class GitInfoCommand : Command, IServiceModule
         Handler = handlerFactory.SimpleHandler<GitInfoHandler, GitInfoArgs>(() => [this]);
     }
 
-    void IServiceModule.ConfigureServices(IServiceCollection services, IConfigurationRoot config)
+    void IServiceModule.ConfigureServices(IServiceCollection services, IConfiguration config)
     {
         services.AddSingleton(new Settings());
         services.AddSingleton<ICommandRunner, CommandRunner>();

--- a/CliTemplate/GitInfo/GitInfoCommand.cs
+++ b/CliTemplate/GitInfo/GitInfoCommand.cs
@@ -1,6 +1,4 @@
-﻿using Larcanum.ShellToolkit;
-
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Command = System.CommandLine.Command;
@@ -18,7 +16,6 @@ public class GitInfoCommand : Command, IServiceModule
 
     void IServiceModule.ConfigureServices(IServiceCollection services, IConfiguration config)
     {
-        services.AddSingleton(new Settings());
-        services.AddSingleton<ICommandRunner, CommandRunner>();
+        services.AddScoped<GitShellCommands>();
     }
 }

--- a/CliTemplate/GitInfo/GitInfoHandler.cs
+++ b/CliTemplate/GitInfo/GitInfoHandler.cs
@@ -1,33 +1,29 @@
-﻿using System.CommandLine;
-using System.CommandLine.Invocation;
+﻿using System.CommandLine.Invocation;
 using System.Text.Json;
 
 using CliTemplate.IO;
-
-using Larcanum.ShellToolkit;
-
-using Microsoft.Extensions.Logging;
 
 namespace CliTemplate.GitInfo;
 
 public class GitInfoHandler : ISimpleHandler<GitInfoArgs>
 {
     private readonly ICliLogger _logger;
-    private readonly ICommandRunner _commandRunner;
+    private readonly GitShellCommands _gitShellCommands;
 
-    public GitInfoHandler(ICliLogger logger, ICommandRunner commandRunner)
+    public GitInfoHandler(ICliLogger logger, GitShellCommands gitShellCommands)
     {
         _logger = logger;
-        _commandRunner = commandRunner;
+        _gitShellCommands = gitShellCommands;
     }
 
-    public async Task<int> RunAsync(InvocationContext context, GitInfoArgs args, CancellationToken cancellationToken = default)
+    public async Task<int> RunAsync(InvocationContext context, GitInfoArgs args, CancellationToken ct = default)
     {
-        var gitInfo = new Dictionary<string, string?>();
-
-        gitInfo["branch"] = (await _commandRunner.CaptureAsync(GitShellCommands.CurrentBranch(args.Path), cancellationToken)).Output?.Trim();
-        gitInfo["commit"] = (await _commandRunner.CaptureAsync(GitShellCommands.CurrentCommit(args.Path), cancellationToken)).Output?.Trim();
-        gitInfo["version"] = (await _commandRunner.CaptureAsync(GitShellCommands.Describe(args.Path), cancellationToken)).Output?.Trim();
+        var gitInfo = new Dictionary<string, string>
+        {
+            ["branch"] = await _gitShellCommands.CurrentBranch(args.Path, ct),
+            ["commit"] = await _gitShellCommands.CurrentCommit(args.Path, ct),
+            ["version"] = await _gitShellCommands.Describe(args.Path, ct)
+        };
 
         _logger.LogContent(JsonSerializer.Serialize(gitInfo, new JsonSerializerOptions { WriteIndented = true }));
 

--- a/CliTemplate/GitInfo/GitShellCommands.cs
+++ b/CliTemplate/GitInfo/GitShellCommands.cs
@@ -2,23 +2,35 @@
 
 namespace CliTemplate.GitInfo;
 
-public static class GitShellCommands
+public class GitShellCommands
 {
     private const string GitExecutable = "git";
 
-    public static ICommand CurrentBranch(string? targetDirectory)
+    private readonly ICommandRunner _shell;
+
+    public GitShellCommands(ICommandRunner shell)
     {
-        return Command.Create(GitExecutable, PrependTarget("branch --show-current", targetDirectory));
+        _shell = shell;
     }
 
-    public static ICommand CurrentCommit(string? targetDirectory)
+    public Task<string> CurrentBranch(string? targetDirectory, CancellationToken ct = default)
     {
-        return Command.Create(GitExecutable, PrependTarget("rev-parse HEAD", targetDirectory));
+        return ShellExecute("branch --show-current", targetDirectory, ct);
     }
 
-    public static ICommand Describe(string? targetDirectory)
+    public Task<string> CurrentCommit(string? targetDirectory, CancellationToken ct = default)
     {
-        return Command.Create(GitExecutable, PrependTarget("describe --tags --dirty --always", targetDirectory));
+        return ShellExecute("rev-parse HEAD", targetDirectory, ct);
+    }
+
+    public Task<string> Describe(string? targetDirectory, CancellationToken ct = default)
+    {
+        return ShellExecute("describe --tags --dirty --always", targetDirectory, ct);
+    }
+
+    private async Task<string> ShellExecute(string args, string? targetDirectory, CancellationToken ct = default)
+    {
+        return (await _shell.CaptureAsync(Command.Create(GitExecutable, PrependTarget(args, targetDirectory)), ct)).Output?.Trim() ?? string.Empty;
     }
 
     private static IEnumerable<string> PrependTarget(string args, string? targetDirectory)

--- a/CliTemplate/HandlerFactory.cs
+++ b/CliTemplate/HandlerFactory.cs
@@ -4,6 +4,8 @@ using System.CommandLine.NamingConventionBinder;
 
 using CliTemplate.IO;
 
+using Larcanum.ShellToolkit;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -14,12 +16,15 @@ public class HandlerFactory
 {
     private readonly IConfiguration _config;
     private readonly ServiceCollection _services;
+    private IServiceProvider? _serviceProvider;
 
     public HandlerFactory(IConfiguration config)
     {
         _config = config;
         _services = new ServiceCollection();
         _services.AddSingleton(_config);
+        _services.AddSingleton(new Settings());
+        _services.AddSingleton<ICommandRunner, CommandRunner>();
     }
 
     public ICommandHandler SimpleHandler<THandler, TArg>()
@@ -33,7 +38,7 @@ public class HandlerFactory
         where THandler : class, ISimpleHandler<TArg>
         where TArg : class
     {
-        _services.AddTransient<ISimpleHandler<TArg>, THandler>();
+        _services.AddScoped<ISimpleHandler<TArg>, THandler>();
         foreach (var mod in modules())
         {
             mod.ConfigureServices(_services, _config);
@@ -41,21 +46,35 @@ public class HandlerFactory
 
         return CommandHandler.Create(async (InvocationContext ctx, TArg arg) =>
         {
-            var commonArgs = CommonArgs.Bind(ctx.BindingContext, _config.GetRequiredSection(CliSettings.SectionName).Get<CliSettings>()!);
+            var provider = EnsureServiceProvider(ctx);
+
+            using var scope = provider.CreateScope();
+            var handler = scope.ServiceProvider.GetRequiredService<ISimpleHandler<TArg>>();
+            return await handler.RunAsync(ctx, arg, ctx.GetCancellationToken());
+        });
+    }
+
+    private IServiceProvider EnsureServiceProvider(InvocationContext ctx)
+    {
+        // Note that the final part of the service collection configuration takes place only once for the initial
+        // command that is being executed and is NOT repeated for child commands. These services are added late
+        // because they depend on the invocation context.
+        if (_serviceProvider == null)
+        {
+            var commonArgs = CommonArgs.Bind(ctx.BindingContext,
+                _config.GetRequiredSection(CliSettings.SectionName).Get<CliSettings>()!);
             // This allows us to access the CommonArgs from within the exception handler in the Launcher
             ctx.BindingContext.AddService(_ => commonArgs);
-
-
+            // This is for injecting the CommonArgs in other places which may end up being useful
             _services.AddSingleton(commonArgs);
-            _services.AddSingleton(arg);
+
             _services.AddSingleton<ICliLogger>(_ => new CliLogger(ctx.Console, commonArgs.ToLogLevel()));
             // This allows injecting the ICliLogger as a normal ILogger
             _services.AddSingleton<ILogger>(provider => provider.GetRequiredService<ICliLogger>());
 
+            _serviceProvider = _services.BuildServiceProvider();
+        }
 
-
-            var handler = _services.BuildServiceProvider().GetRequiredService<ISimpleHandler<TArg>>();
-            return await handler.RunAsync(ctx, arg, ctx.GetCancellationToken());
-        });
+        return _serviceProvider;
     }
 }

--- a/CliTemplate/HandlerFactory.cs
+++ b/CliTemplate/HandlerFactory.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CliTemplate;
 
-public class HandlerFactory
+public class HandlerFactory : IChildLauncher
 {
     private readonly IConfiguration _config;
     private readonly ServiceCollection _services;
@@ -25,6 +25,7 @@ public class HandlerFactory
         _services.AddSingleton(_config);
         _services.AddSingleton(new Settings());
         _services.AddSingleton<ICommandRunner, CommandRunner>();
+        _services.AddSingleton<IChildLauncher>(this);
     }
 
     public ICommandHandler SimpleHandler<THandler, TArg>()
@@ -46,12 +47,17 @@ public class HandlerFactory
 
         return CommandHandler.Create(async (InvocationContext ctx, TArg arg) =>
         {
-            var provider = EnsureServiceProvider(ctx);
-
-            using var scope = provider.CreateScope();
-            var handler = scope.ServiceProvider.GetRequiredService<ISimpleHandler<TArg>>();
-            return await handler.RunAsync(ctx, arg, ctx.GetCancellationToken());
+            return await RunAsync(ctx, arg, ctx.GetCancellationToken());
         });
+    }
+
+    public async Task<int> RunAsync<TArg>(InvocationContext ctx, TArg arg, CancellationToken ct)
+    {
+        var provider = EnsureServiceProvider(ctx);
+
+        using var scope = provider.CreateScope();
+        var handler = scope.ServiceProvider.GetRequiredService<ISimpleHandler<TArg>>();
+        return await handler.RunAsync(ctx, arg, ct);
     }
 
     private IServiceProvider EnsureServiceProvider(InvocationContext ctx)

--- a/CliTemplate/HandlerFactory.cs
+++ b/CliTemplate/HandlerFactory.cs
@@ -16,6 +16,7 @@ public class HandlerFactory : IChildLauncher
 {
     private readonly IConfiguration _config;
     private readonly ServiceCollection _services;
+    private readonly HashSet<string> _loadedModules = new HashSet<string>();
     private IServiceProvider? _serviceProvider;
 
     public HandlerFactory(IConfiguration config)
@@ -42,7 +43,12 @@ public class HandlerFactory : IChildLauncher
         _services.AddScoped<ISimpleHandler<TArg>, THandler>();
         foreach (var mod in modules())
         {
-            mod.ConfigureServices(_services, _config);
+            var moduleKey = mod.GetType().FullName ?? mod.ToString();
+            if (moduleKey == null || !_loadedModules.Contains(moduleKey))
+            {
+                mod.ConfigureServices(_services, _config);
+                _loadedModules.Add(moduleKey ?? string.Empty);
+            }
         }
 
         return CommandHandler.Create(async (InvocationContext ctx, TArg arg) =>

--- a/CliTemplate/HandlerFactory.cs
+++ b/CliTemplate/HandlerFactory.cs
@@ -12,14 +12,14 @@ namespace CliTemplate;
 
 public class HandlerFactory
 {
-    private readonly IConfigurationRoot _config;
+    private readonly IConfiguration _config;
     private readonly ServiceCollection _services;
 
-    public HandlerFactory(IConfigurationRoot config)
+    public HandlerFactory(IConfiguration config)
     {
         _config = config;
         _services = new ServiceCollection();
-        _services.AddSingleton<IConfiguration>(config);
+        _services.AddSingleton(_config);
     }
 
     public ICommandHandler SimpleHandler<THandler, TArg>()
@@ -34,6 +34,10 @@ public class HandlerFactory
         where TArg : class
     {
         _services.AddTransient<ISimpleHandler<TArg>, THandler>();
+        foreach (var mod in modules())
+        {
+            mod.ConfigureServices(_services, _config);
+        }
 
         return CommandHandler.Create(async (InvocationContext ctx, TArg arg) =>
         {
@@ -41,17 +45,14 @@ public class HandlerFactory
             // This allows us to access the CommonArgs from within the exception handler in the Launcher
             ctx.BindingContext.AddService(_ => commonArgs);
 
-            _services.AddSingleton(_config);
+
             _services.AddSingleton(commonArgs);
             _services.AddSingleton(arg);
             _services.AddSingleton<ICliLogger>(_ => new CliLogger(ctx.Console, commonArgs.ToLogLevel()));
             // This allows injecting the ICliLogger as a normal ILogger
             _services.AddSingleton<ILogger>(provider => provider.GetRequiredService<ICliLogger>());
 
-            foreach (var mod in modules())
-            {
-                mod.ConfigureServices(_services, _config);
-            }
+
 
             var handler = _services.BuildServiceProvider().GetRequiredService<ISimpleHandler<TArg>>();
             return await handler.RunAsync(ctx, arg, ctx.GetCancellationToken());

--- a/CliTemplate/IChildLauncher.cs
+++ b/CliTemplate/IChildLauncher.cs
@@ -1,0 +1,8 @@
+﻿using System.CommandLine.Invocation;
+
+namespace CliTemplate;
+
+public interface IChildLauncher
+{
+    public Task<int> RunAsync<TArg>(InvocationContext ctx, TArg arg, CancellationToken ct);
+}

--- a/CliTemplate/IServiceModule.cs
+++ b/CliTemplate/IServiceModule.cs
@@ -5,5 +5,5 @@ namespace CliTemplate;
 
 public interface IServiceModule
 {
-    void ConfigureServices(IServiceCollection services, IConfigurationRoot config);
+    void ConfigureServices(IServiceCollection services, IConfiguration config);
 }

--- a/CliTemplate/ISimpleHandler.cs
+++ b/CliTemplate/ISimpleHandler.cs
@@ -4,5 +4,5 @@ namespace CliTemplate;
 
 public interface ISimpleHandler<TArg>
 {
-    Task<int> RunAsync(InvocationContext context, TArg args, CancellationToken cancellationToken = default);
+    Task<int> RunAsync(InvocationContext context, TArg args, CancellationToken ct = default);
 }

--- a/CliTemplate/Launcher.cs
+++ b/CliTemplate/Launcher.cs
@@ -54,15 +54,21 @@ public class Launcher
         var logLevel = commonArgs?.ToLogLevel() ?? LogLevel.Information;
         var logger = new CliLogger(ctx.Console, logLevel);
 
-        if (ex is OperationCanceledException canceledException)
+        switch (ex)
         {
-            logger.LogWarning($"The operation was aborted - {canceledException.Message}");
-            ctx.ExitCode = ExitCodes.Aborted;
-            return;
+            case OperationCanceledException cEx:
+                logger.LogWarning($"The operation was aborted - {cEx.Message}");
+                ctx.ExitCode = ExitCodes.Aborted;
+                return;
+            case CommandFailureException cfEx:
+                LogException(logger, logLevel, cfEx);
+                ctx.ExitCode = cfEx.ExitCode;
+                return;
+            default:
+                LogException(logger, logLevel, ex);
+                ctx.ExitCode = ExitCodes.UnhandledException;
+                break;
         }
-
-        LogException(logger, logLevel, ex);
-        ctx.ExitCode = ExitCodes.UnhandledException;
     }
 
     private static void LogException(ICliLogger logger, LogLevel logLevel, Exception e)

--- a/CliTemplate/Launcher.cs
+++ b/CliTemplate/Launcher.cs
@@ -1,11 +1,14 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
-using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Reflection;
 
+using CliTemplate.IO;
+
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace CliTemplate;
 
@@ -47,14 +50,30 @@ public class Launcher
 
     private static void OnException(Exception ex, InvocationContext ctx)
     {
-        if (ex is OperationCanceledException)
+        var commonArgs = ctx.BindingContext.GetService<CommonArgs>();
+        var logLevel = commonArgs?.ToLogLevel() ?? LogLevel.Information;
+        var logger = new CliLogger(ctx.Console, logLevel);
+
+        if (ex is OperationCanceledException canceledException)
         {
-            ctx.Console.WriteLine("The operation was aborted");
+            logger.LogWarning($"The operation was aborted - {canceledException.Message}");
             ctx.ExitCode = ExitCodes.Aborted;
             return;
         }
 
-        ctx.Console.Error.WriteLine(ex.ToString());
+        LogException(logger, logLevel, ex);
         ctx.ExitCode = ExitCodes.UnhandledException;
+    }
+
+    private static void LogException(ICliLogger logger, LogLevel logLevel, Exception e)
+    {
+        if (logLevel <= LogLevel.Debug)
+        {
+            logger.LogError(e, e.ToString());
+        }
+        else if (logLevel <= LogLevel.Error)
+        {
+            logger.LogError(e.Message);
+        }
     }
 }

--- a/CliTemplate/Launcher.cs
+++ b/CliTemplate/Launcher.cs
@@ -15,7 +15,7 @@ public class Launcher
 
     public Launcher()
     {
-        IConfigurationRoot config = new ConfigurationBuilder()
+        var config = new ConfigurationBuilder()
             .AddJsonFile("appSettings.json")
             .AddJsonFile("secrets.user.json", optional: true)
             .AddJsonFile("secrets.json", optional: true)

--- a/CliTemplate/Status/StatusCommand.cs
+++ b/CliTemplate/Status/StatusCommand.cs
@@ -14,7 +14,7 @@ public class StatusCommand : Command, IServiceModule
         Handler = handlerFactory.SimpleHandler<StatusHandler, StatusArgs>(() => [this]);
     }
 
-    void IServiceModule.ConfigureServices(IServiceCollection services, IConfigurationRoot config)
+    void IServiceModule.ConfigureServices(IServiceCollection services, IConfiguration config)
     {
         services.AddSingleton(new DelayConfig(config));
     }

--- a/CliTemplate/Status/StatusHandler.cs
+++ b/CliTemplate/Status/StatusHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 
+using CliTemplate.GitInfo;
 using CliTemplate.IO;
 
 using Microsoft.Extensions.Logging;
@@ -10,11 +11,13 @@ namespace CliTemplate.Status;
 public class StatusHandler : ISimpleHandler<StatusArgs>
 {
     private readonly ICliLogger _logger;
+    private readonly IChildLauncher _childLauncher;
     private readonly DelayConfig _config;
 
-    public StatusHandler(ICliLogger logger, DelayConfig config)
+    public StatusHandler(ICliLogger logger, IChildLauncher childLauncher, DelayConfig config)
     {
         _logger = logger;
+        _childLauncher = childLauncher;
         _config = config;
         _logger.LogInformation("StatusHandler created with CLI logger");
     }
@@ -23,6 +26,7 @@ public class StatusHandler : ISimpleHandler<StatusArgs>
     {
         _logger.LogContent("Hello StatusHandler!");
         await Task.Delay(_config.Delay, cancellationToken);
+        await _childLauncher.RunAsync(context, new GitInfoArgs(), cancellationToken);
         _logger.LogContent("Done");
 
         return ExitCodes.Ok;

--- a/CliTemplate/Status/StatusHandler.cs
+++ b/CliTemplate/Status/StatusHandler.cs
@@ -22,11 +22,11 @@ public class StatusHandler : ISimpleHandler<StatusArgs>
         _logger.LogInformation("StatusHandler created with CLI logger");
     }
 
-    public async Task<int> RunAsync(InvocationContext context, StatusArgs args, CancellationToken cancellationToken = default)
+    public async Task<int> RunAsync(InvocationContext context, StatusArgs args, CancellationToken ct = default)
     {
         _logger.LogContent("Hello StatusHandler!");
-        await Task.Delay(_config.Delay, cancellationToken);
-        await _childLauncher.RunAsync(context, new GitInfoArgs(), cancellationToken);
+        await Task.Delay(_config.Delay, ct);
+        await _childLauncher.RunAsync(context, new GitInfoArgs(), ct);
         _logger.LogContent("Done");
 
         return ExitCodes.Ok;


### PR DESCRIPTION
A bit of refactoring to allow any command to call into any other command with the new `IChildLauncher` service. This required some potentially breaking changes to the `HandlerFactory`:
- All `IServiceModule` dependencies of commands are now called to configure their services during the registration process and not only when a specific command is actually called. This is necessary because otherwise we would not be able to provide a single, consistent `IServiceProvider` with properly scoped services.
- Commands are now being executed inside of a service scope, making scoped services possible
- The arguments of command handlers (the `TArg` instance) is no longer registered as a service since that would again require a separate service provider for each child command call.